### PR TITLE
Adventure content plan: Keith dock + fish house unboxing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ADVENTURE_CONTENT_PLAN.md
+++ b/ADVENTURE_CONTENT_PLAN.md
@@ -1,5 +1,7 @@
 # Adventure content plan — Keith (northern Minnesota)
 
+**Master synthesized spec:** `MASTER_PRODUCT_BRIEF.md` — creative + production + monetization in one page; this file is the deep dive (especially sponsorship research).
+
 Single reference for shoot format, family details, hooks, and sponsorship thinking. (Meeting context: transcribed notes — correct spellings below.)
 
 ## Who

--- a/ADVENTURE_CONTENT_PLAN.md
+++ b/ADVENTURE_CONTENT_PLAN.md
@@ -44,15 +44,47 @@ Real family, real place, real vehicles: unbox → try → ride. Personal and kin
 
 **Important:** Nobody can honestly label this “profitable” without your **actual** subscriber counts, average views per video, upload cadence, and costs. Below is **how the market tends to work** and **what to budget mentally**.
 
-### How big outdoor retailers usually play
+### Bass Pro Shops **and** Cabela’s (treat as one ecosystem)
 
-- Public activity for brands like **Bass Pro Shops**, **Cabela’s** (same parent company as Bass Pro), and **Fleet Farm** skews toward **large** partnerships: tournaments, platforms, NASCAR, conservation events — not ad-hoc “send us pallets” DMs to new channels.
-- **That does not mean “no.”** It means the credible path is usually: **consistent published work** → clear **media kit** (audience, geography, demographics, typical views, engagement) → outreach via **affiliate programs**, **local store** marketing contacts, or **creator/marketing agencies** — not an assumption of free bulk overstock.
+- **Same parent company** (Bass Pro acquired Cabela’s). National marketing you see in the press skews **large**: conservation events, tournaments, NASCAR, platform deals — not typical “DM us for a pallet” creator sponsorships.
+- **Credible near-term levers for creators** (verify current terms when you apply):
+  - **Affiliate / partner programs** — Both brands run **cost-per-sale** style programs; industry write-ups and help-center pages point to networks such as **Impact** (and others) with **category-dependent** commission bands (often **lower** on firearms/ammo, **higher** on general outdoor gear). Cookie windows are often **~14 days** in third-party summaries — confirm in the official agreement.
+  - **In-store value** — **Cabela’s Bargain Cave** (and similar clearance) is where **shoppers** find deals; it is **not** the same as getting **bulk returns** from headquarters. Use it to **source episodes affordably**, not as a substitute for a sponsor.
+- **Who to talk to:** Affiliate program application first; **local store** events/community desks only after you have a **short deck** (audience, Minnesota angle, sample episode, disclosure compliance).
 
-### Walgreens / general retail overstock
+### Walmart (corrected from transcript: **not** Walgreens)
 
-- **Walgreens** is primarily **health, beauty, consumables** — a poor thematic fit for a **fishing + camo hunting** channel unless you deliberately widen the premise (which dilutes the hook).
-- **Overstock** deals are unpredictable; **mystery** unboxing adds **brand control** and **safety** issues (brands rarely want unknown SKUs going out unvetted). Treat any “pallets of random stuff” idea as **high friction**, not the first dependency.
+- **Fit:** Broad **fishing, camping, camo, coolers, ATVs accessories** — workable for episodes even though it is mass retail, not a specialty vibe.
+- **Official creator path — Walmart Creator Program** ([WalmartCreator.com](https://creator.walmart.com/); corporate overview Nov 2025): creators earn **commission** on **commissionable** purchases through **Qualifying Links**; **Walmart Creator Collabs** adds **higher commissions** on select **Marketplace** products via brand partnerships.
+- **Eligibility (from Walmart Creator Terms, updated March 2026):** **18+**, **U.S. resident**, active **Walmart.com** account, **not** a Walmart associate, **≥ 1,000 followers** across **connected** social accounts, at least one **public** social profile. Walmart approves/rejects in its discretion.
+- **Open box / returns:** **Do not assume** you can walk into corporate and buy **returns pallets** for content. **Liquidation** is usually **B2B** (jobbers, liquidators). For content, use **Walmart Creator links** on **clearance / rollbacks** you feature transparently, or buy retail like any customer.
+
+### Other companies to consider (sponsorship, affiliates, or buying gear for episodes)
+
+| Company | Why it fits this concept | What to look up / try |
+|--------|---------------------------|------------------------|
+| **Fleet Farm** | Upper Midwest footprint; hunting, fishing, farm, outdoor — **local** to Minnesota story | Store events, local marketing; **national** creator deals are less visible publicly — start **regional**. |
+| **SCHEELS** | Huge outdoor assortment; **official Creator Program** (storefront-style links, commissions — details on [scheels.com/creator-program](https://www.scheels.com/creator-program/)) | Apply to program; good **regional** cultural fit. |
+| **DICK’S Sporting Goods / Field & Stream** | Fishing + hunting + apparel at scale | **Impact**-style **affiliate** programs are widely listed by third-party aggregators; rates vary by network — apply and read **exact** terms. |
+| **Academy Sports + Outdoors** | Similar big-box outdoor mix | Official **academy.com/affiliate-program** + network programs; commissions are often **modest** in affiliate-directory listings. |
+| **Sportsman’s Warehouse** | Hunting/fishing specialty chain | Check **current** corporate affiliate or partnership pages; treat old blog aggregates as **hints only**. |
+| **Catch Co. / Karl’s Bait & Tackle / Mystery Tackle Box** | **Native fishing** brand energy; built around **subscriptions** and **creators** unboxing tackle | Affiliate paths exist via commerce networks; **Mystery Tackle Box** is a natural **format match**. Catch Co has run **creator competitions** in the past (e.g. **“On the Line”** — search for current year if they repeat). |
+| **Rapala, Strike King, Lew’s, Plano, etc.** | Hardgoods tackle brands | **Pro staff** / field-staff programs (often **smaller** perks, not cash) → can still **lend credibility** early. |
+| **YETI, RTIC, Igloo, Pelican** | Coolers + outdoor **props** that read on camera | **YETI** publishes **ambassador** stories (heavily **curated**); treat as **aspirational**, not a first-week pitch unless numbers justify it. |
+| **Polaris / BRP / local powersports dealers** | Snowmobiles + wheelers are already in your hook | **Local dealer** co-marketing is often more realistic than factory **YouTube** deals at small scale. |
+
+### “Unique” or creator-heavy plays (outdoor / retail) — use as models, not guarantees
+
+- **Influencer-built product lines** — e.g. **Googan Squad** × **Catch Co.** (tackle sold through **major retailers including Walmart**): shows how **audience + product** can merge; that tier took **years** and **millions** of reach.
+- **Retailer-native creator infrastructure** — **Walmart Creator** + **Creator Collabs**; **SCHEELS Creator Program**: structured **commissions** instead of one-off gifts.
+- **Subscription unbox** — **Mystery Tackle Box**-style formats already **train** viewers to expect monthly gear reveals — aligns with your mystery-bait idea.
+- **Big outdoor retail PR** — Bass Pro’s public deals (tournaments, **Fishing Chaos**, conservation) show where **dollars** flow at **corporate** level — useful for **context**, not a template for day-one outreach.
+
+### Open-box, returns, and liquidation — straight talk
+
+- **Retailers rarely sell “open box / returns” streams to random creators** as a marketing SKU. **Customer returns** and **unsold stock** usually flow to **liquidators**, jobbers, or internal outlet channels — **not** “film crew pickup.”
+- **What *is* realistic:** **Bargain Cave** / clearance aisles / endcaps; **Facebook Marketplace** or **estate** sales for **props**; **affiliate** revenue when viewers buy **new** items you showcased; **paid** integrations once you have **proof of performance**.
+- **Mystery unboxing of unknown SKUs** creates **brand-risk** for partners (safety, MAP pricing, counterfeits). Sponsors prefer **approved** products and **scripted** talking points.
 
 ### Rough creator-economics context (generic industry guides)
 
@@ -64,8 +96,8 @@ Real family, real place, real vehicles: unbox → try → ride. Personal and kin
 | Stage | Focus |
 |--------|--------|
 | **0–1** | Self-funded or small local brands; nail **3–5** strong episodes; **FTC-compliant** disclosures; consistent **title/thumbnail** hook (UPS delivery bit). |
-| **Growth** | Media kit + outbound to **regional** outdoor retailers and **affiliate** links (rod/reel, apparel) while pitching **national** brands with proof. |
-| **Scale** | Agency or manager if inbound deals multiply. |
+| **Growth** | Media kit + **Walmart Creator** (if eligible) + **SCHEELS** / **Bass Pro–Cabela’s** affiliates + **Catch Co** / tackle affiliates; pitch **regional** dealers and **Fleet Farm**-class stores with proof. |
+| **Scale** | Agency or manager if inbound deals multiply; only then lean hard into **national** outdoor HQ marketing budgets. |
 
 ---
 
@@ -87,4 +119,4 @@ Fill these when you can — they matter more than another gear idea:
 - **Camo hunting + fishing** gear mix.  
 - **Dock + fish house** (year-round, movable); lean on **cabin**, **boat**, **ice house** amenities for variety.  
 - **Jagr & Beau** drive the **UPS** delivery bit; **Jojo** and **Jaye** as fits the episode.  
-- **Sponsorship** is a **stretch goal**; build **proof library** first, then pitch with data.
+- **Sponsorship targets:** **Bass Pro Shops**, **Cabela’s**, **Walmart** (Creator Program), **Fleet Farm**, **SCHEELS**, tackle-native brands (**Catch Co. / Karl’s / MTB**), plus **affiliate** paths while building a **proof library** — then pitch **paid** deals with data.

--- a/ADVENTURE_CONTENT_PLAN.md
+++ b/ADVENTURE_CONTENT_PLAN.md
@@ -9,7 +9,7 @@ Single reference for shoot format, family details, hooks, and sponsorship thinki
 | Dad | **Keith** | Early 40s; strong on-camera with the kids; family is on board. |
 | Sons | **Jager** (J-A-G-E-R), **Beau** (B-E-A-U) | Each has a **snowmobile** and a **four-wheeler**. |
 | Daughter | **Jojo** | |
-| Mom | **Jade** (J-A-D-E) | |
+| Mom | **Jaye** (J-A-Y-E) | |
 
 ## Places & assets
 
@@ -86,5 +86,5 @@ Fill these when you can — they matter more than another gear idea:
 
 - **Camo hunting + fishing** gear mix.  
 - **Dock + fish house** (year-round, movable); lean on **cabin**, **boat**, **ice house** amenities for variety.  
-- **Jager & Beau** drive the **UPS** delivery bit; **Jojo** and **Jade** as fits the episode.  
+- **Jager & Beau** drive the **UPS** delivery bit; **Jojo** and **Jaye** as fits the episode.  
 - **Sponsorship** is a **stretch goal**; build **proof library** first, then pitch with data.

--- a/ADVENTURE_CONTENT_PLAN.md
+++ b/ADVENTURE_CONTENT_PLAN.md
@@ -1,0 +1,30 @@
+# Adventure content plan — Keith (northern Minnesota)
+
+Locked-in creative direction from the planning session. Use this as the single reference for shoot format and roles.
+
+## Who
+
+- **Keith** — early 40s; two sons and a younger daughter.
+- **Location context** — Trips to northern Minnesota (Hackensack area, Birch Lake).
+
+## Format
+
+- **Dock unboxing** with the boys (and family as needed).
+- **Filming locations (Q1):** Use **both** the **dock** and **inside the fish house** — not either/or.
+
+## Gear focus (Q2)
+
+- **Full mix:** fishing (rods, lures, related tackle) **and** hunting / outdoor kit.
+- Session wording included “camel hunting”; treat as **camo / hunting** unless you standardize different copy.
+
+## Kids’ roles (Q3)
+
+Kids **do the full arc:**
+
+1. Open the boxes on camera.
+2. **Test** the mystery bait (and gear) on camera — not passive watching only.
+3. **Haul / deliver** gear on a **snowmobile** or **four-wheeler** (session joke: “like UPS”) — strong B-roll and adventure beat.
+
+## Story angle
+
+Outdoor, multi-activity trip energy: clear water, docks, fish house, family doing real steps (unbox → try → ride). Keeps the piece personal and kinetic rather than a static tabletop unboxing.

--- a/ADVENTURE_CONTENT_PLAN.md
+++ b/ADVENTURE_CONTENT_PLAN.md
@@ -7,7 +7,7 @@ Single reference for shoot format, family details, hooks, and sponsorship thinki
 | Role | Name | Notes |
 |------|------|--------|
 | Dad | **Keith** | Early 40s; strong on-camera with the kids; family is on board. |
-| Sons | **Jager** (J-A-G-E-R), **Beau** (B-E-A-U) | Each has a **snowmobile** and a **four-wheeler**. |
+| Sons | **Jagr** (J-A-G-R), **Beau** (B-E-A-U) | Each has a **snowmobile** and a **four-wheeler**. |
 | Daughter | **Jojo** | |
 | Mom | **Jaye** (J-A-Y-E) | |
 
@@ -86,5 +86,5 @@ Fill these when you can — they matter more than another gear idea:
 
 - **Camo hunting + fishing** gear mix.  
 - **Dock + fish house** (year-round, movable); lean on **cabin**, **boat**, **ice house** amenities for variety.  
-- **Jager & Beau** drive the **UPS** delivery bit; **Jojo** and **Jaye** as fits the episode.  
+- **Jagr & Beau** drive the **UPS** delivery bit; **Jojo** and **Jaye** as fits the episode.  
 - **Sponsorship** is a **stretch goal**; build **proof library** first, then pitch with data.

--- a/ADVENTURE_CONTENT_PLAN.md
+++ b/ADVENTURE_CONTENT_PLAN.md
@@ -1,30 +1,90 @@
 # Adventure content plan — Keith (northern Minnesota)
 
-Locked-in creative direction from the planning session. Use this as the single reference for shoot format and roles.
+Single reference for shoot format, family details, hooks, and sponsorship thinking. (Meeting context: transcribed notes — correct spellings below.)
 
 ## Who
 
-- **Keith** — early 40s; two sons and a younger daughter.
-- **Location context** — Trips to northern Minnesota (Hackensack area, Birch Lake).
+| Role | Name | Notes |
+|------|------|--------|
+| Dad | **Keith** | Early 40s; strong on-camera with the kids; family is on board. |
+| Sons | **Jager** (J-A-G-E-R), **Beau** (B-E-A-U) | Each has a **snowmobile** and a **four-wheeler**. |
+| Daughter | **Jojo** | |
+| Mom | **Jade** (J-A-D-E) | |
+
+## Places & assets
+
+- **Hackensack, Minnesota** — home base for this content; Birch Lake area context.
+- **Cabin** — Keith’s family **owns** a cabin up north; speaker’s **parents** also have a place there → lots of natural shoot locations and repeat visits.
+- **Boats** — available for summer / open-water beats.
+- **Fish house / ice house** — usable **summer and winter**; **can be moved** (relocate for different shots or lake positions).
+- **Ice house interior** — **kitchenette**, **bunk beds**, **TV** → indoor lifestyle + unboxing set that still feels “up north,” not a studio table.
 
 ## Format
 
-- **Dock unboxing** with the boys (and family as needed).
-- **Filming locations (Q1):** Use **both** the **dock** and **inside the fish house** — not either/or.
+- **Unboxing** with the boys (and family as needed) — dock, cabin, and/or fish house.
+- **Filming locations:** **Both** the **dock** and **inside the fish house** (not either/or). Add **cabin** and **boat** when it serves the story.
 
-## Gear focus (Q2)
+## Gear focus
 
-- **Full mix:** fishing (rods, lures, related tackle) **and** hunting / outdoor kit.
-- Session wording included “camel hunting”; treat as **camo / hunting** unless you standardize different copy.
+- **Full mix:** fishing (rods, lures, tackle) **and** **camo / hunting** gear — **not** “camel”; transcription was **camouflage** hunting.
 
-## Kids’ roles (Q3)
+## Kids’ roles (creative + hook)
 
-Kids **do the full arc:**
-
-1. Open the boxes on camera.
-2. **Test** the mystery bait (and gear) on camera — not passive watching only.
-3. **Haul / deliver** gear on a **snowmobile** or **four-wheeler** (session joke: “like UPS”) — strong B-roll and adventure beat.
+1. **Open** boxes on camera.
+2. **Test** mystery bait / gear on camera (not passive).
+3. **“UPS” hook:** Kids **deliver** packages on **snowmobile** (winter / ice) or **four-wheeler** when out **hunting** — catchy visual, clear recurring bit, strong B-roll.
 
 ## Story angle
 
-Outdoor, multi-activity trip energy: clear water, docks, fish house, family doing real steps (unbox → try → ride). Keeps the piece personal and kinetic rather than a static tabletop unboxing.
+Real family, real place, real vehicles: unbox → try → ride. Personal and kinetic; leverages what they already own (cabins, boats, sleds, wheelers, tricked-out fish house).
+
+---
+
+## Sponsorship & economics (research-backed, not a forecast)
+
+**Important:** Nobody can honestly label this “profitable” without your **actual** subscriber counts, average views per video, upload cadence, and costs. Below is **how the market tends to work** and **what to budget mentally**.
+
+### How big outdoor retailers usually play
+
+- Public activity for brands like **Bass Pro Shops**, **Cabela’s** (same parent company as Bass Pro), and **Fleet Farm** skews toward **large** partnerships: tournaments, platforms, NASCAR, conservation events — not ad-hoc “send us pallets” DMs to new channels.
+- **That does not mean “no.”** It means the credible path is usually: **consistent published work** → clear **media kit** (audience, geography, demographics, typical views, engagement) → outreach via **affiliate programs**, **local store** marketing contacts, or **creator/marketing agencies** — not an assumption of free bulk overstock.
+
+### Walgreens / general retail overstock
+
+- **Walgreens** is primarily **health, beauty, consumables** — a poor thematic fit for a **fishing + camo hunting** channel unless you deliberately widen the premise (which dilutes the hook).
+- **Overstock** deals are unpredictable; **mystery** unboxing adds **brand control** and **safety** issues (brands rarely want unknown SKUs going out unvetted). Treat any “pallets of random stuff” idea as **high friction**, not the first dependency.
+
+### Rough creator-economics context (generic industry guides)
+
+- Third-party **pricing guides** for **YouTube** often quote **micro** creators (roughly **10k–100k** subscribers) on the order of **hundreds to low thousands of dollars per sponsored integration**, scaled by **average views** and **niche** — but **outdoor/fishing** is not broken out consistently; treat numbers as **order-of-magnitude**, not a quote for your channel.
+- **Profit** = sponsorships + ads + affiliates **minus** gear you buy, travel, music licensing, editing, and time. Early phase is often **negative** until audience compounding shows up.
+
+### Practical tiering
+
+| Stage | Focus |
+|--------|--------|
+| **0–1** | Self-funded or small local brands; nail **3–5** strong episodes; **FTC-compliant** disclosures; consistent **title/thumbnail** hook (UPS delivery bit). |
+| **Growth** | Media kit + outbound to **regional** outdoor retailers and **affiliate** links (rod/reel, apparel) while pitching **national** brands with proof. |
+| **Scale** | Agency or manager if inbound deals multiply. |
+
+---
+
+## What would really help next (gaps in the brief)
+
+Fill these when you can — they matter more than another gear idea:
+
+1. **Platform + metrics** — YouTube vs TikTok vs both; current **subs**, **median views** (last 10 videos), **posting frequency** goal.
+2. **Audience** — Who you believe is watching (dads, Minnesota locals, fishing-only, hunting crossover).
+3. **Budget band** — Dollars you’re willing to spend **before** any sponsor pays (product, travel, music, editor).
+4. **Legal / safety** — **FTC** sponsorship/disclosure rules for kids and parents on camera; **helmet / riding** shots and liability; **music** (licensed or platform-safe).
+5. **Product strategy** — If **no** sponsor yet: where boxes come from (buy-down, brand seeding, PR lists) so episodes stay consistent.
+6. **One-line pitch** — e.g. “Minnesota family unboxes outdoor gear; kids deliver the boxes by sled or wheeler and test it on the lake and in the field.”
+
+---
+
+## Locked creative summary
+
+- **Camo hunting + fishing** gear mix.  
+- **Dock + fish house** (year-round, movable); lean on **cabin**, **boat**, **ice house** amenities for variety.  
+- **Jager & Beau** drive the **UPS** delivery bit; **Jojo** and **Jade** as fits the episode.  
+- **Sponsorship** is a **stretch goal**; build **proof library** first, then pitch with data.

--- a/FAMILY_PROOF_OF_CONCEPT.md
+++ b/FAMILY_PROOF_OF_CONCEPT.md
@@ -1,0 +1,55 @@
+# Proof of concept — for Keith, Jaye, and the kids
+
+**What this is:** A simple, shareable write-up so everyone **sees the same picture** before you commit real time or energy. It is **not** a contract and **not** set in stone — we can change or drop it anytime. Think of it as **alignment**, not a permanent plan.
+
+**Who it’s for:** Keith, Jaye, Jagr, Beau, Jojo — and anyone helping behind the camera.
+
+---
+
+## The idea in plain language
+
+We’re exploring a **fun video concept** built around your real life up north: **Hackensack / Birch Lake**, the **cabin**, the **dock**, the **fish house** (summer or winter — it moves, it has the kitchenette, bunks, TV), the **boats**, and the **snowmobiles / four-wheelers**.
+
+**The bit:** The kids help **“deliver”** boxes to the spot where you’ll open them — like a mini **UPS** run on a sled or wheeler — then you **unbox** outdoor gear ( **fishing** and **camo / hunting** stuff), and you **actually try it** on the water or in the field, not just talk about it.
+
+**Why it’s strong for you:** You already have the **location**, the **vehicles**, and the **family chemistry**. The videos would feel **real**, not staged in someone else’s studio.
+
+---
+
+## What we’d be asking of the family
+
+Nothing here is a demand — it’s **what “good” could look like** if you all say yes.
+
+- **Keith & Jaye:** On camera when it feels natural; **safety calls** for the kids and machines; **honest reactions** (funny or skeptical is fine).
+- **Jagr & Beau:** **Delivery** shots (sled / wheeler), **unboxing**, and **trying** gear — at a pace that stays **safe** and **fun**, not stressful.
+- **Jojo:** In the mix when she **wants** to be; no pressure to carry every scene.
+- **Everyone:** **Clear “no”** is always OK — if a day, a shot, or a whole idea doesn’t work, we adjust or stop.
+
+---
+
+## What I’m bringing (out of me)
+
+- **Clarity:** This doc and any updates so nobody’s guessing what we’re trying.
+- **Respect for your time:** Reasonable shoot lengths, no guilt if schedules don’t line up.
+- **Transparency:** If something is sponsored, affiliate, or paid, **you’ll know before** we present it that way — and we’ll follow **disclosure** rules (especially with kids on camera).
+- **Flexibility:** This stays a **proof of concept** until you’re comfortable; we can pilot **one short session** and decide.
+
+---
+
+## What to expect (process)
+
+1. **Read this** — see if the vibe matches what you want.  
+2. **Talk it through** — questions, boundaries, “hard no” topics.  
+3. **Optional pilot** — one small filming window; see how it feels.  
+4. **Decide together** — keep going, change the format, or call it a good experiment.
+
+---
+
+## If you want more detail
+
+- **`MASTER_PRODUCT_BRIEF.md`** — slightly fuller “show” outline (still not permanent).  
+- **`ADVENTURE_CONTENT_PLAN.md`** — deeper notes, including sponsor ideas **for later** (not something the family needs to worry about on day one).
+
+---
+
+**Bottom line:** This is so Keith, Jaye, and the kids **know what we’re picturing** and **what could be asked of them** — and so you know **what I’m trying to hold up on my side**. When something’s wrong for your family, we change the plan.

--- a/MASTER_PRODUCT_BRIEF.md
+++ b/MASTER_PRODUCT_BRIEF.md
@@ -1,0 +1,92 @@
+# Master product brief — “Up North Delivery” (working title)
+
+**Status:** Single synthesized spec — creative + production + monetization.  
+**Detail drill-down:** See `ADVENTURE_CONTENT_PLAN.md` for sponsorship research, retailer table, and citations.
+
+---
+
+## One-sentence product
+
+A **Minnesota cabin family** (Keith, Jaye, Jagr, Beau, Jojo) films **outdoor gear unboxings** where the boys **deliver boxes like a mini UPS crew** on **snowmobiles** or **four-wheelers**, then **actually use** the fishing and camo-hunting gear **on the dock, in the fish house, on the boat, and in the field** — real place, real vehicles, no fake studio.
+
+---
+
+## What the “final product” is (deliverable)
+
+| Layer | Output |
+|--------|--------|
+| **Viewer-facing** | Serialized video (YouTube long-form ± Shorts / TikTok cuts) with a **repeatable cold open**: delivery → unbox → test → payoff shot (fish, hunt prep, or ride B-roll). |
+| **Brand-facing** | A **small proof library** (3–5 strong episodes) + **media kit** (audience, geography, median views, disclosure compliance) before expecting **paid** sponsorships. |
+| **Money-facing** | Phased stack: **self-funded / clearance sourcing** → **affiliate links** (Walmart Creator, SCHEELS, Bass Pro–Cabela’s, Catch Co. / MTB-class programs) → **regional** co-marketing (dealers, Fleet Farm–class) → **national** paid deals when metrics justify it. |
+
+---
+
+## Creative spine (non-negotiables)
+
+1. **Gear mix:** Fishing **and** **camo / hunting** — never “camel”; always **camouflage** outdoor.
+2. **Locations:** **Dock + fish house** every arc; add **cabin**, **boat**, **ice** as the episode needs. Fish house is **year-round**, **movable**; interior (**kitchenette**, **bunks**, **TV**) is a character, not clutter.
+3. **Kids are protagonists:** They **open**, **test** mystery bait / gear, and **drive the delivery bit** — not wallpaper.
+4. **UPS hook:** Jagr & Beau **deliver** packages on **sled** (winter / ice) or **wheeler** (hunting context). Same gag, new boxes — **franchise memory**.
+
+---
+
+## Default episode structure (template)
+
+| Block | Purpose |
+|--------|---------|
+| **0:00–0:30** | Hook: wheels + box (“delivery”) — motion, sound, lake or trail. |
+| **0:30–3:00** | Unbox + real reactions; Keith / Jaye as needed for safety or context. |
+| **3:00–8:00+** | **Use** the gear: cast, set a line, pattern a hunt prep, organize tackle in the fish house — **proof**, not only hype. |
+| **Outro** | Tease next delivery or next season (ice vs open water). |
+
+Cut **Shorts** from: delivery approach, first reveal, one fish or one funny fail, wheeler/sled glam.
+
+---
+
+## Cast & place (snapshot)
+
+- **Keith** — dad, anchor, great with kids on camera.  
+- **Jaye** — mom; use when it fits the beat.  
+- **Jagr**, **Beau** — sons; each has **snowmobile + four-wheeler**.  
+- **Jojo** — daughter; fold in when natural.  
+- **Hackensack / Birch Lake** — owned **cabin**, family **boats**, **parents’ place** nearby → depth of return visits without “one weekend” energy.
+
+---
+
+## Production guardrails
+
+- **FTC:** Clear **#ad** / **paid link** / **partner** when anything is sponsored or affiliate — especially with **minors** on camera.  
+- **Safety:** Helmets, machine rules, ice conditions; don’t improvise stunts for views.  
+- **Audio / music:** Platform-safe or licensed; wind on the lake will punish bad audio — plan **lav or close mic** for unbox beats.  
+- **Product control:** Prefer **known SKUs** you chose or sponsors approved; random liquidation mystery pallets = **brand and safety risk** (see full plan).
+
+---
+
+## Monetization roadmap (merged from “all agents”)
+
+| Phase | Goal | Tactics |
+|--------|------|---------|
+| **0 — Proof** | 3–5 episodes that look intentional | Self-buy, clearance, Bargain Cave–style deals, maybe **MTB**-style sub box; nail **title + thumbnail + UPS hook**. |
+| **1 — Affiliates** | Legal income without begging HQ | **Walmart Creator** (needs **1k+** followers across linked accounts, U.S., 18+ — see Walmart Creator Terms), **SCHEELS Creator**, **Bass Pro / Cabela’s** affiliate networks, **Catch Co. / Karl’s / MTB** where applicable. |
+| **2 — Regional** | Local credibility | **Fleet Farm**, **powersports dealers**, local bait shops — co-promo or small trade. |
+| **3 — National paid** | Real CPM deals | Media kit + consistent uploads; pitch **Bass Pro / Cabela’s** marketing only when numbers support it. |
+
+**Profit truth:** Depends on **your** views, cadence, and costs — not on the idea alone.
+
+---
+
+## Information still needed (complete the master brief)
+
+1. **Primary platform** and **handles**.  
+2. **Median views** (last 10 videos) and **subscriber** count.  
+3. **Upload cadence** you can sustain (monthly vs weekly).  
+4. **Pre-revenue budget** (gear, editor, music, travel).  
+5. **Official show name** + **thumbnail style** (one template, repeated).
+
+---
+
+## Final lock — “what we’re building”
+
+**Product:** A **repeatable outdoor family unboxing show** with a **delivery stunt** and **real use** in **northern Minnesota**, optimized first for **audience proof**, second for **affiliate fit** (Walmart, SCHEELS, Bass Pro–Cabela’s, fishing-native brands), third for **bigger retail** and **paid** partnerships.
+
+**Reference:** All retailer detail, links, and research notes live in **`ADVENTURE_CONTENT_PLAN.md`**.

--- a/MASTER_PRODUCT_BRIEF.md
+++ b/MASTER_PRODUCT_BRIEF.md
@@ -1,6 +1,7 @@
 # Master product brief — “Up North Delivery” (working title)
 
 **Status:** Single synthesized spec — creative + production + monetization.  
+**Sharing with Keith & family (not permanent — just alignment):** `FAMILY_PROOF_OF_CONCEPT.md`  
 **Detail drill-down:** See `ADVENTURE_CONTENT_PLAN.md` for sponsorship research, retailer table, and citations.
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `ADVENTURE_CONTENT_PLAN.md` with corrected transcription (camo, not camel), full family names (Keith, **Jaye**, Jager, Beau, Jojo), Hackensack/cabin/boat/sled/wheeler/fish house details (including summer+winter movable ice house with kitchenette, bunks, TV), the UPS delivery hook, and a research-grounded section on sponsorship economics plus a checklist of information gaps to fill next.

Also includes `.gitignore` for `node_modules/` (earlier commit on this branch).

## Notes

- Documentation only; no game code changes.
- Sponsorship section states limitations: national outdoor retailers skew to large partnerships; credible path is proof of audience + media kit + affiliates/local contacts; Walgreens is a weak thematic fit for fishing/camo hunting.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a6dd5be-f64d-42c0-a968-1c18d3a2bae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a6dd5be-f64d-42c0-a968-1c18d3a2bae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

