### PR TITLE
fix(content-shield): repair setuptools backend and CI test extra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/content-shield/pyproject.toml
+++ b/content-shield/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "content-shield"
@@ -35,6 +35,11 @@ slack = ["slack-sdk>=3.0"]
 agents = ["google-generativeai>=0.3", "anthropic>=0.20", "openai>=1.0"]
 dashboard = ["grafanalib>=0.7"]
 all = ["content-shield[gcp,slack,agents,dashboard]"]
+test = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "pytest-cov>=4.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two high-confidence issues introduced with the content-shield scaffold (merged PR #10) that would break a real CI run when workflows are wired to this package.

## Bugs reproduced

1. **Invalid PEP 517 build backend** — `pip install -e .` failed with `BackendUnavailable: Cannot import 'setuptools.backends._legacy'` because `pyproject.toml` pointed at a non-importable backend path.

2. **Missing `[test]` extra** — `content-shield/.github/workflows/ci.yml` runs `pip install -e ".[test]"`, but `pyproject.toml` did not define a `test` optional dependency group, which would cause resolution to fail once the build backend issue was fixed.

## Changes

- Set `build-backend` to `setuptools.build_meta`.
- Add `optional-dependencies.test` with pytest, pytest-asyncio, and pytest-cov (aligned with Makefile `test` target).
- Add root `.gitignore` entry for `node_modules/` so local npm installs are not left as untracked noise.

## Verification

- `python -m pip install -e ".[test]"` in `content-shield/` succeeds.
- `python -m pytest --tb=short -q` — 129 passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5391bd3b-8ce5-463c-8177-91370a72e762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5391bd3b-8ce5-463c-8177-91370a72e762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

