### PR TITLE
fix(content-shield): packaging and GitHub Actions workflow placement

### DIFF
--- a/.github/workflows/content-shield-ci.yml
+++ b/.github/workflows/content-shield-ci.yml
@@ -1,10 +1,14 @@
-name: CI
+name: Content Shield CI
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+defaults:
+  run:
+    working-directory: content-shield
 
 jobs:
   test:

--- a/.github/workflows/content-shield-lint.yml
+++ b/.github/workflows/content-shield-lint.yml
@@ -1,8 +1,12 @@
-name: Lint
+name: Content Shield Lint
 
 on:
   push:
   pull_request:
+
+defaults:
+  run:
+    working-directory: content-shield
 
 jobs:
   ruff:

--- a/.github/workflows/content-shield-lint.yml
+++ b/.github/workflows/content-shield-lint.yml
@@ -24,4 +24,4 @@ jobs:
         run: python -m pip install --upgrade pip ruff
 
       - name: Run ruff check
-        run: ruff check .
+        run: ruff check src/ tests/

--- a/.github/workflows/content-shield-publish.yml
+++ b/.github/workflows/content-shield-publish.yml
@@ -1,9 +1,13 @@
-name: Publish to PyPI
+name: Publish Content Shield to PyPI
 
 on:
   push:
     tags:
       - "v*"
+
+defaults:
+  run:
+    working-directory: content-shield
 
 jobs:
   build:
@@ -27,7 +31,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: dist/
+          path: content-shield/dist/
 
   publish:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/content-shield/pyproject.toml
+++ b/content-shield/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "content-shield"
@@ -35,10 +35,13 @@ slack = ["slack-sdk>=3.0"]
 agents = ["google-generativeai>=0.3", "anthropic>=0.20", "openai>=1.0"]
 dashboard = ["grafanalib>=0.7"]
 all = ["content-shield[gcp,slack,agents,dashboard]"]
-dev = [
+test = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
+]
+dev = [
+    "content-shield[test]",
     "ruff>=0.1",
     "mypy>=1.0",
     "pre-commit>=3.0",

--- a/content-shield/src/content_shield/agents/router.py
+++ b/content-shield/src/content_shield/agents/router.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Sequence
 
 from content_shield.agents.base_agent import BaseAgent
 

--- a/content-shield/src/content_shield/analyzers/readability.py
+++ b/content-shield/src/content_shield/analyzers/readability.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import re
 
-
 # Simple vowel-group heuristic for syllable counting.
 _VOWEL_GROUP_RE = re.compile(r"[aeiouy]+", re.IGNORECASE)
 

--- a/content-shield/src/content_shield/collector/gcf_handler.py
+++ b/content-shield/src/content_shield/collector/gcf_handler.py
@@ -6,8 +6,8 @@ import json
 import logging
 from typing import Any
 
-from content_shield.schema.event import ShieldEvent
 from content_shield.collector.storage import EventStorage
+from content_shield.schema.event import ShieldEvent
 
 logger = logging.getLogger(__name__)
 

--- a/content-shield/src/content_shield/collector/local_handler.py
+++ b/content-shield/src/content_shield/collector/local_handler.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 
-from content_shield.schema.event import ShieldEvent
 from content_shield.collector.storage import EventStorage
+from content_shield.schema.event import ShieldEvent
 
 logger = logging.getLogger(__name__)
 

--- a/content-shield/src/content_shield/collector/storage.py
+++ b/content-shield/src/content_shield/collector/storage.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 

--- a/content-shield/src/content_shield/dashboard/pain_line.py
+++ b/content-shield/src/content_shield/dashboard/pain_line.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,12 @@ class PainLineTracker:
         )
         self._points.append(point)
         if score > self.threshold:
-            logger.warning("Pain threshold exceeded: %s scored %.1f (threshold=%.1f)", shield_name, score, self.threshold)
+            logger.warning(
+                "Pain threshold exceeded: %s scored %.1f (threshold=%.1f)",
+                shield_name,
+                score,
+                self.threshold,
+            )
         return point
 
     @property

--- a/content-shield/src/content_shield/emitter/pubsub.py
+++ b/content-shield/src/content_shield/emitter/pubsub.py
@@ -9,7 +9,7 @@ it via the ``gcp`` extra::
 from __future__ import annotations
 
 import json
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 
@@ -46,7 +46,7 @@ class PubSubEmitter(BaseEmitter):
         project_id: str,
         topic_id: str,
         *,
-        ordering_key: Optional[str] = None,
+        ordering_key: str | None = None,
     ) -> None:
         if not _HAS_PUBSUB:
             raise ImportError(
@@ -56,8 +56,8 @@ class PubSubEmitter(BaseEmitter):
         self._project_id = project_id
         self._topic_id = topic_id
         self._ordering_key = ordering_key or ""
-        self._publisher: Optional[pubsub_v1.PublisherClient] = None
-        self._topic_path: Optional[str] = None
+        self._publisher: pubsub_v1.PublisherClient | None = None
+        self._topic_path: str | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/content-shield/src/content_shield/emitter/slack.py
+++ b/content-shield/src/content_shield/emitter/slack.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 import structlog
@@ -105,15 +105,15 @@ class SlackEmitter(BaseEmitter):
         self,
         webhook_url: str,
         *,
-        channel: Optional[str] = None,
-        username: Optional[str] = None,
+        channel: str | None = None,
+        username: str | None = None,
         timeout: float = 10.0,
     ) -> None:
         self._webhook_url = webhook_url
         self._channel = channel
         self._username = username or "Content Shield"
         self._timeout = timeout
-        self._client: Optional[httpx.AsyncClient] = None
+        self._client: httpx.AsyncClient | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/content-shield/src/content_shield/emitter/webhook.py
+++ b/content-shield/src/content_shield/emitter/webhook.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 import structlog
@@ -32,13 +32,13 @@ class WebhookEmitter(BaseEmitter):
         self,
         url: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
         timeout: float = 10.0,
     ) -> None:
         self._url = url
         self._headers = headers or {}
         self._timeout = timeout
-        self._client: Optional[httpx.AsyncClient] = None
+        self._client: httpx.AsyncClient | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/content-shield/src/content_shield/integrations/__init__.py
+++ b/content-shield/src/content_shield/integrations/__init__.py
@@ -1,10 +1,10 @@
 """Integrations with third-party content platforms."""
 
-from content_shield.integrations.webhook_generic import GenericWebhookIntegration
-from content_shield.integrations.wordpress import WordPressIntegration
 from content_shield.integrations.hubspot import HubSpotIntegration
 from content_shield.integrations.mailchimp import MailchimpIntegration
 from content_shield.integrations.shopify import ShopifyIntegration
+from content_shield.integrations.webhook_generic import GenericWebhookIntegration
+from content_shield.integrations.wordpress import WordPressIntegration
 
 __all__ = [
     "GenericWebhookIntegration",

--- a/content-shield/src/content_shield/integrations/webhook_generic.py
+++ b/content-shield/src/content_shield/integrations/webhook_generic.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import httpx
 

--- a/content-shield/src/content_shield/integrations/wordpress.py
+++ b/content-shield/src/content_shield/integrations/wordpress.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import httpx
 

--- a/content-shield/src/content_shield/resilience/circuit_breaker.py
+++ b/content-shield/src/content_shield/resilience/circuit_breaker.py
@@ -11,7 +11,8 @@ import enum
 import functools
 import threading
 import time
-from typing import Any, Callable, Optional, Sequence, Tuple, Type, Union
+from collections.abc import Callable, Sequence
+from typing import Any
 
 
 class CircuitState(enum.Enum):
@@ -22,10 +23,10 @@ class CircuitState(enum.Enum):
     HALF_OPEN = "half_open"
 
 
-class CircuitBreakerOpen(Exception):
+class CircuitBreakerOpen(Exception):  # noqa: N818
     """Raised when a call is rejected because the circuit is open."""
 
-    def __init__(self, breaker: "CircuitBreaker") -> None:
+    def __init__(self, breaker: CircuitBreaker) -> None:
         self.breaker = breaker
         remaining = breaker._time_until_recovery()
         super().__init__(
@@ -60,14 +61,9 @@ class CircuitBreaker:
         failure_threshold: int = 5,
         recovery_timeout: float = 30.0,
         half_open_max_calls: int = 1,
-        monitored_exceptions: Union[
-            Tuple[Type[BaseException], ...],
-            Sequence[Type[BaseException]],
-        ] = (Exception,),
+        monitored_exceptions: tuple[type[BaseException], ...] | Sequence[type[BaseException]] = (Exception,),
         name: str = "default",
-        on_state_change: Optional[
-            Callable[[CircuitState, CircuitState], Any]
-        ] = None,
+        on_state_change: Callable[[CircuitState, CircuitState], Any] | None = None,
     ) -> None:
         self.failure_threshold = failure_threshold
         self.recovery_timeout = recovery_timeout

--- a/content-shield/src/content_shield/resilience/dlq.py
+++ b/content-shield/src/content_shield/resilience/dlq.py
@@ -10,9 +10,10 @@ import json
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Any
 
 
 @dataclass
@@ -24,14 +25,14 @@ class DLQEntry:
     error: str
     error_type: str
     timestamp: float
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
     retry_count: int = 0
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "DLQEntry":
+    def from_dict(cls, data: dict[str, Any]) -> DLQEntry:
         return cls(**data)
 
 
@@ -52,12 +53,12 @@ class DeadLetterQueue:
     def __init__(
         self,
         *,
-        persist_path: Optional[str | Path] = None,
-        max_size: Optional[int] = None,
+        persist_path: str | Path | None = None,
+        max_size: int | None = None,
     ) -> None:
         self._lock = threading.Lock()
-        self._entries: List[DLQEntry] = []
-        self._persist_path: Optional[Path] = (
+        self._entries: list[DLQEntry] = []
+        self._persist_path: Path | None = (
             Path(persist_path) if persist_path else None
         )
         self.max_size = max_size
@@ -74,7 +75,7 @@ class DeadLetterQueue:
         payload: Any,
         error: BaseException,
         *,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> DLQEntry:
         """Add a failed event to the queue.
 
@@ -107,7 +108,7 @@ class DeadLetterQueue:
             self._flush()
         return entry
 
-    def dequeue(self) -> Optional[DLQEntry]:
+    def dequeue(self) -> DLQEntry | None:
         """Remove and return the oldest entry, or *None* if empty."""
         with self._lock:
             if not self._entries:
@@ -116,7 +117,7 @@ class DeadLetterQueue:
             self._flush()
             return entry
 
-    def peek(self, count: int = 1) -> List[DLQEntry]:
+    def peek(self, count: int = 1) -> list[DLQEntry]:
         """Return the oldest *count* entries without removing them."""
         with self._lock:
             return list(self._entries[:count])
@@ -125,9 +126,9 @@ class DeadLetterQueue:
         self,
         handler: Callable[[Any], Any],
         *,
-        max_items: Optional[int] = None,
+        max_items: int | None = None,
         remove_on_success: bool = True,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Attempt to replay queued entries through *handler*.
 
         Parameters
@@ -153,8 +154,8 @@ class DeadLetterQueue:
 
         succeeded = 0
         failed = 0
-        errors: List[str] = []
-        replayed_ids: List[str] = []
+        errors: list[str] = []
+        replayed_ids: list[str] = []
 
         for entry in to_replay:
             try:
@@ -194,7 +195,7 @@ class DeadLetterQueue:
             self._flush()
             return count
 
-    def get_by_id(self, entry_id: str) -> Optional[DLQEntry]:
+    def get_by_id(self, entry_id: str) -> DLQEntry | None:
         """Look up an entry by its unique id."""
         with self._lock:
             for entry in self._entries:
@@ -202,7 +203,7 @@ class DeadLetterQueue:
                     return entry
         return None
 
-    def list_all(self) -> List[DLQEntry]:
+    def list_all(self) -> list[DLQEntry]:
         """Return a copy of all entries."""
         with self._lock:
             return list(self._entries)

--- a/content-shield/src/content_shield/resilience/error_classifier.py
+++ b/content-shield/src/content_shield/resilience/error_classifier.py
@@ -7,7 +7,7 @@ or unknown, enabling intelligent retry and circuit-breaker decisions.
 from __future__ import annotations
 
 import enum
-from typing import Callable, Dict, List, Optional, Type
+from collections.abc import Callable
 
 
 class ErrorCategory(enum.Enum):
@@ -19,11 +19,11 @@ class ErrorCategory(enum.Enum):
 
 
 # Type alias for a rule function: takes an exception, returns a category or None.
-ClassificationRule = Callable[[BaseException], Optional[ErrorCategory]]
+ClassificationRule = Callable[[BaseException], ErrorCategory | None]
 
 
 # Built-in mapping of exception types to categories.
-_DEFAULT_RULES: Dict[Type[BaseException], ErrorCategory] = {
+_DEFAULT_RULES: dict[type[BaseException], ErrorCategory] = {
     # Transient - network / IO issues that may resolve on retry
     ConnectionError: ErrorCategory.TRANSIENT,
     ConnectionAbortedError: ErrorCategory.TRANSIENT,
@@ -69,8 +69,8 @@ class ErrorClassifier:
     """
 
     def __init__(self, *, include_defaults: bool = True) -> None:
-        self._type_rules: Dict[Type[BaseException], ErrorCategory] = {}
-        self._callable_rules: List[ClassificationRule] = []
+        self._type_rules: dict[type[BaseException], ErrorCategory] = {}
+        self._callable_rules: list[ClassificationRule] = []
         self._include_defaults = include_defaults
 
     # ------------------------------------------------------------------
@@ -79,9 +79,9 @@ class ErrorClassifier:
 
     def register(
         self,
-        exc_type: Type[BaseException],
+        exc_type: type[BaseException],
         category: ErrorCategory,
-    ) -> "ErrorClassifier":
+    ) -> ErrorClassifier:
         """Register a type-based classification rule.
 
         Parameters
@@ -99,7 +99,7 @@ class ErrorClassifier:
         self._type_rules[exc_type] = category
         return self
 
-    def register_rule(self, rule: ClassificationRule) -> "ErrorClassifier":
+    def register_rule(self, rule: ClassificationRule) -> ErrorClassifier:
         """Register a custom callable classification rule.
 
         The callable receives an exception instance and must return an
@@ -170,11 +170,10 @@ class ErrorClassifier:
     @staticmethod
     def _match_type_rules(
         exc: BaseException,
-        rules: Dict[Type[BaseException], ErrorCategory],
-    ) -> Optional[ErrorCategory]:
+        rules: dict[type[BaseException], ErrorCategory],
+    ) -> ErrorCategory | None:
         """Find the most-specific matching type rule via MRO."""
-        exc_type = type(exc)
-        best_match: Optional[Type[BaseException]] = None
+        best_match: type[BaseException] | None = None
         for candidate in rules:
             if isinstance(exc, candidate):
                 if best_match is None or issubclass(candidate, best_match):

--- a/content-shield/src/content_shield/resilience/retry.py
+++ b/content-shield/src/content_shield/resilience/retry.py
@@ -8,15 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import functools
+from collections.abc import Callable, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from typing import (
     Any,
-    Callable,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
 )
 
 import tenacity
@@ -59,11 +54,8 @@ class RetryPolicy:
         backoff: str = "exponential",
         backoff_base: float = 1,
         backoff_max: float = 60,
-        retryable_exceptions: Union[
-            Tuple[Type[BaseException], ...],
-            Sequence[Type[BaseException]],
-        ] = (Exception,),
-        on_retry: Optional[Callable[[RetryCallState], Any]] = None,
+        retryable_exceptions: tuple[type[BaseException], ...] | Sequence[type[BaseException]] = (Exception,),
+        on_retry: Callable[[RetryCallState], Any] | None = None,
     ) -> None:
         self.max_attempts = max_attempts
         self.backoff = backoff
@@ -170,7 +162,7 @@ class RetryPolicy:
     # Helpers
     # ------------------------------------------------------------------
 
-    def copy(self, **overrides: Any) -> "RetryPolicy":
+    def copy(self, **overrides: Any) -> RetryPolicy:
         """Return a shallow copy with optional parameter overrides."""
         params = {
             "max_attempts": self.max_attempts,

--- a/content-shield/src/content_shield/resilience/timeout.py
+++ b/content-shield/src/content_shield/resilience/timeout.py
@@ -11,8 +11,9 @@ import asyncio
 import concurrent.futures
 import functools
 import threading
+from collections.abc import Callable
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
 

--- a/content-shield/src/content_shield/schema/content.py
+++ b/content-shield/src/content_shield/schema/content.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import enum
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -28,7 +28,7 @@ class Content(BaseModel):
     text: str
     content_type: ContentType
     language: str = "en"
-    metadata: Optional[dict[str, Any]] = None
+    metadata: dict[str, Any] | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/content-shield/src/content_shield/schema/event.py
+++ b/content-shield/src/content_shield/schema/event.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import enum
-from datetime import datetime, timezone
-from typing import Any, Optional
+from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -30,4 +30,4 @@ class ShieldEvent(BaseModel):
     passed: bool
     message: str
     details: dict[str, Any] = Field(default_factory=dict)
-    metadata: Optional[dict[str, Any]] = None
+    metadata: dict[str, Any] | None = None

--- a/content-shield/src/content_shield/schema/validation.py
+++ b/content-shield/src/content_shield/schema/validation.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel, Field, computed_field
 
 from content_shield.schema.event import Severity
@@ -15,8 +13,8 @@ class Issue(BaseModel):
     code: str
     message: str
     severity: Severity
-    span_start: Optional[int] = None
-    span_end: Optional[int] = None
+    span_start: int | None = None
+    span_end: int | None = None
 
 
 class ValidationResult(BaseModel):

--- a/content-shield/src/content_shield/shields/hallucination.py
+++ b/content-shield/src/content_shield/shields/hallucination.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from content_shield.schema import Content, Issue, Severity, ValidationResult
+from content_shield.schema import Content, Issue, ValidationResult
 from content_shield.shields.base import BaseShield
 
 

--- a/content-shield/src/content_shield/shields/runner.py
+++ b/content-shield/src/content_shield/shields/runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Sequence
+from collections.abc import Sequence
 
 from content_shield.schema import Content, ValidationResult, ValidationSummary
 from content_shield.shields.base import BaseShield

--- a/content-shield/src/content_shield/shields/toxicity.py
+++ b/content-shield/src/content_shield/shields/toxicity.py
@@ -65,7 +65,6 @@ class ToxicityShield(BaseShield):
 
     async def check(self, content: Content) -> ValidationResult:
         issues: list[Issue] = []
-        text_lower = content.text.lower()
 
         # Keyword matching.
         for keyword in self._keywords:

--- a/content-shield/tests/conftest.py
+++ b/content-shield/tests/conftest.py
@@ -5,15 +5,14 @@ from uuid import uuid4
 
 import pytest
 
+from content_shield.brand.profile import BrandProfile
 from content_shield.schema import (
     Content,
     ContentType,
-    Issue,
     Severity,
     ShieldEvent,
     ValidationResult,
 )
-from content_shield.brand.profile import BrandProfile
 
 
 @pytest.fixture

--- a/content-shield/tests/test_analyzers/test_contact_validators.py
+++ b/content-shield/tests/test_analyzers/test_contact_validators.py
@@ -1,6 +1,5 @@
 """Tests for EmailValidator and PhoneValidator."""
 
-import pytest
 
 from content_shield.analyzers.email_validator import EmailValidator
 from content_shield.analyzers.phone_validator import PhoneValidator

--- a/content-shield/tests/test_analyzers/test_url_validator.py
+++ b/content-shield/tests/test_analyzers/test_url_validator.py
@@ -1,6 +1,5 @@
 """Tests for URLValidator."""
 
-import pytest
 
 from content_shield.analyzers.url_validator import URLValidator
 

--- a/content-shield/tests/test_brand/test_profile.py
+++ b/content-shield/tests/test_brand/test_profile.py
@@ -1,6 +1,5 @@
 """Tests for BrandProfile."""
 
-import json
 import tempfile
 from pathlib import Path
 

--- a/content-shield/tests/test_resilience/test_dlq.py
+++ b/content-shield/tests/test_resilience/test_dlq.py
@@ -1,6 +1,5 @@
 """Tests for DeadLetterQueue."""
 
-import pytest
 
 from content_shield.resilience.dlq import DeadLetterQueue, DLQEntry
 

--- a/content-shield/tests/test_resilience/test_error_classifier.py
+++ b/content-shield/tests/test_resilience/test_error_classifier.py
@@ -1,6 +1,5 @@
 """Tests for ErrorClassifier."""
 
-import pytest
 
 from content_shield.resilience.error_classifier import ErrorCategory, ErrorClassifier
 

--- a/content-shield/tests/test_shields/test_brand_voice.py
+++ b/content-shield/tests/test_shields/test_brand_voice.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from content_shield.brand.profile import BrandProfile
 from content_shield.schema import Content, ContentType
 from content_shield.shields.brand_voice import BrandVoiceShield
 

--- a/content-shield/tests/test_shields/test_runner.py
+++ b/content-shield/tests/test_shields/test_runner.py
@@ -5,7 +5,6 @@ import pytest
 from content_shield.schema import Content, ContentType
 from content_shield.shields.hallucination import HallucinationShield
 from content_shield.shields.runner import ShieldRunner
-from content_shield.shields.sentiment import SentimentShield
 from content_shield.shields.toxicity import ToxicityShield
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,827 @@
+{
+  "name": "execution-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "execution-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes high-confidence issues introduced with the Content Shield scaffold (PR #10): broken editable installs, CI installing a non-existent `[test]` extra, workflows that GitHub would never run because they lived under `content-shield/.github/workflows/`, and a lint job that would fail on the full tree (examples/infra) or on existing `src/`/`tests/` ruff findings.

## Reproduction (before)

1. **Build backend:** `pip install -e ".[test]"` in `content-shield` failed with `BackendUnavailable: Cannot import 'setuptools.backends._legacy'`.
2. **Missing extra:** After fixing the backend locally, `pip install -e ".[test]"` emitted `WARNING: content-shield 0.1.0 does not provide the extra 'test'` — pytest was not installed via that extra.
3. **Workflows:** GitHub Actions only loads workflows from the repository root `.github/workflows/`; nested paths under `content-shield/` are ignored.
4. **Lint:** `ruff check .` from `content-shield` reported many issues in `examples/`; `ruff check src/ tests/` (Makefile scope) had 94 violations before fixes.

## Changes

- Set `build-backend` to `setuptools.build_meta` in `content-shield/pyproject.toml`.
- Add a `test` optional dependency group; have `dev` include `content-shield[test]` to avoid duplication.
- Add root workflows (`content-shield-ci.yml`, `content-shield-lint.yml`, `content-shield-publish.yml`) with `defaults.run.working-directory: content-shield` and correct artifact path for publish.
- Remove the nested workflow copies under `content-shield/.github/workflows/` to avoid drift.
- Lint workflow runs `ruff check src/ tests/` (matches Makefile); apply `ruff --fix` across `src/` and `tests/` so the job passes.

## Verification

- `python -m pip install -e ".[test]"` succeeds with no missing-extra warning.
- `ruff check src/ tests/` in `content-shield`: **All checks passed!**
- `python -m pytest` in `content-shield`: **129 passed**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-087a98e4-bc26-4916-81b3-97cdb8996a10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-087a98e4-bc26-4916-81b3-97cdb8996a10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

