### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Repository overview
+
+This repo contains two independent products:
+
+1. **Express test server** (root `/workspace/`) — A trivial Express.js server (`server.js`) on port 3000 with intentionally buggy endpoints. Node.js deps are in `package.json` with `package-lock.json`.
+2. **Content Shield** (`/workspace/content-shield/`) — A Python AI content quality validation framework. Source is in `content-shield/src/content_shield/`, tests in `content-shield/tests/`. Config is in `content-shield/pyproject.toml`.
+
+There is also a Roblox Luau game (Palm Springs Paradise) under `src/`, which requires Roblox Studio and cannot be run in a headless cloud VM.
+
+### Running services
+
+- **Express server:** `node server.js` from repo root (port 3000). Test with `curl http://localhost:3000/hello?name=Test`.
+- **Content Shield:** Python package, no long-running server. Used as a library / via tests.
+
+### Python environment (content-shield)
+
+The `pyproject.toml` has an **invalid build-backend** (`setuptools.backends._legacy:_Backend`). This means `pip install -e .` and `pip install .` will both fail. Instead, install dependencies manually and use `PYTHONPATH`:
+
+```bash
+cd /workspace/content-shield
+source .venv/bin/activate
+export PYTHONPATH=/workspace/content-shield/src:$PYTHONPATH
+```
+
+The venv is at `/workspace/content-shield/.venv`. All commands below assume it is activated.
+
+### Key commands
+
+| Task | Command | Working directory |
+|------|---------|-------------------|
+| Install Node deps | `npm install` | `/workspace` |
+| Install Python deps | `pip install "pydantic>=2.0" "httpx>=0.25" "tenacity>=8.0" "structlog>=23.0" "pytest>=7.0" "pytest-asyncio>=0.21" "pytest-cov>=4.0" "ruff>=0.1" "mypy>=1.0"` | (with venv active) |
+| Run Python tests | `PYTHONPATH=src:$PYTHONPATH pytest --cov=content_shield --cov-report=term-missing` | `/workspace/content-shield` |
+| Run Python lint | `ruff check src/ tests/` | `/workspace/content-shield` |
+| Run type check | `PYTHONPATH=src:$PYTHONPATH mypy src/content_shield/` | `/workspace/content-shield` |
+| Start Express server | `node server.js` | `/workspace` |
+
+### Pre-existing issues
+
+- **Ruff lint:** 98 pre-existing lint errors (mostly F401 unused imports). These are in the existing code, not introduced by setup.
+- **Mypy:** 59 pre-existing type errors. These are in the existing code.
+- **Build backend:** `pyproject.toml` specifies `setuptools.backends._legacy:_Backend` which does not exist in any setuptools version. Workaround is manual dep install + PYTHONPATH.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this repository, which contains two main products:

1. **Express test server** (root) — Node.js/Express on port 3000
2. **Content Shield** (`content-shield/`) — Python AI content validation framework

### What's included

- **`AGENTS.md`** with cloud-specific development instructions, including:
  - Repository structure overview
  - Python venv setup with `pyproject.toml` build-backend workaround (the existing `setuptools.backends._legacy:_Backend` backend is invalid)
  - Key commands for lint/test/run
  - Pre-existing issue documentation (98 ruff errors, 59 mypy errors)

### Environment verification

**Express server** — Both endpoints respond correctly:
- `GET /hello?name=DevEnvironment` → `{"message":"Hello DevEnvironment!"}`
- `GET /add?a=42&b=58` → `{"result":100}`

**Content Shield** — All 129 tests pass:

[dev_env_verification.log](https://cursor.com/artifacts/c/art-b9ccdd47-26ef-4195-a38b-ef634e9c3d28)

### Update script

The VM startup update script handles:
- `npm install` for Express server deps
- Python venv creation (if needed) + pip install of all content-shield dependencies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c3a7213-075b-4cbb-9e0d-fd2d9bd047a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c3a7213-075b-4cbb-9e0d-fd2d9bd047a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

