### PR TITLE
Windows handoff: fix Rojo serve and Rokit toolchain pins

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,6 +47,10 @@
       "label": "Toolchain: Verify",
       "type": "shell",
       "command": "bash staging/scripts/toolchain/verify.sh",
+      "windows": {
+        "command": "powershell -ExecutionPolicy Bypass -File staging/scripts/toolchain/verify.ps1"
+      },
+      "options": { "cwd": "${workspaceFolder}" },
       "problemMatcher": []
     },
     {

--- a/default.project.json
+++ b/default.project.json
@@ -4,25 +4,20 @@
     "$className": "DataModel",
 
     "ServerScriptService": {
-      "$className": "ServerScriptService",
       "$path": "src/server"
     },
 
     "StarterPlayer": {
-      "$className": "StarterPlayer",
       "StarterPlayerScripts": {
-        "$className": "StarterPlayerScripts",
         "$path": "src/client"
       }
     },
 
     "ReplicatedStorage": {
-      "$className": "ReplicatedStorage",
       "$path": "src/shared"
     },
 
     "StarterGui": {
-      "$className": "StarterGui",
       "$path": "src/gui"
     },
 

--- a/docs/karlux/07-step-by-step-install-windows.md
+++ b/docs/karlux/07-step-by-step-install-windows.md
@@ -216,6 +216,7 @@ In game chat:
 | Problem | Fix |
 |---------|-----|
 | Scripts blocked | `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` in PowerShell |
+| Rokit “not trusted” | Approve prompts, or run: `rokit trust JohnnyMorganz/StyLua rojo-rbx/rojo UpliftGames/wally seaofvoices/darklua rojo-rbx/remodel Kampfkarren/selene` then `rokit install` |
 | `rojo` not found | Add `%USERPROFILE%\.rokit\bin` to User PATH, restart Cursor |
 | Rojo won’t connect | Allow firewall for `rojo`; confirm `rojo serve` running |
 | `mklink` failed | Use `Copy-Item` for rokit.toml / wally.toml (Step 3) |

--- a/docs/karlux/HANDOFF-condensed.md
+++ b/docs/karlux/HANDOFF-condensed.md
@@ -108,7 +108,7 @@ docs/karlux/            # Architecture + install docs
 
 ## Known issues / notes
 
-- `rojo build` may error on `ServerScriptService` class conflict — **use `rojo serve` + Studio** as primary loop
+- `default.project.json` must not set `$className` on nodes that use `$path` to script trees (fixed on this branch); primary loop is **`rojo serve` + Studio**
 - Supabase **mock** in Play Solo without Roblox Secrets
 - Cloud agent cannot open local Cursor — user runs commands on Windows machine
 - `.env` never commit; copy from `staging/env/.env.example`

--- a/staging/scripts/krlx-workspace-bootstrap.ps1
+++ b/staging/scripts/krlx-workspace-bootstrap.ps1
@@ -33,8 +33,12 @@ if (-not (Test-Path "wally.toml")) {
 }
 
 if (Get-Command rokit -ErrorAction SilentlyContinue) {
-    Write-Host "Installing Rokit tools..."
+    Write-Host "Installing Rokit tools (approve trust prompts if shown)..."
     rokit install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "If install failed on trust, run: rokit trust JohnnyMorganz/StyLua rojo-rbx/rojo UpliftGames/wally seaofvoices/darklua rojo-rbx/remodel Kampfkarren/selene" -ForegroundColor Yellow
+        rokit install
+    }
 } else {
     Write-Host "WARN: rokit not found. Run Step 2 in 07-step-by-step-install-windows.md" -ForegroundColor Yellow
 }

--- a/staging/toolchain/rokit.toml
+++ b/staging/toolchain/rokit.toml
@@ -8,8 +8,6 @@ wally   = "UpliftGames/wally@0.3.2"
 stylua  = "JohnnyMorganz/StyLua@2.0.2"
 darklua = "seaofvoices/darklua@0.13.0"
 remodel = "rojo-rbx/remodel@0.11.0"
-# Tarmac: publish via Roblox/Tarmac when available in Rokit index;
-# fallback: cargo install rosty-tarmac or aftman entry (see aftman.toml)
-tarmac  = "Roblox/Tarmac@1.0.0"
 selene  = "Kampfkarren/selene@0.28.0"
-StyLua = "JohnnyMorganz/StyLua@2.0.2"
+# Tarmac optional — Studio Import 3D is primary; uncomment if Rokit index resolves:
+# tarmac  = "Roblox/Tarmac@1.0.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unblocks the Windows + Cursor handoff path (Steps 3–7) on branch `cursor/karlux-foundation-292d`.

## Changes

- **rokit.toml:** Remove duplicate `StyLua` entry and comment out default `tarmac` pin (Studio Import 3D remains primary).
- **default.project.json:** Drop conflicting `$className` on `$path` nodes so `rojo serve` starts cleanly.
- **.vscode/tasks.json:** Run `verify.ps1` on Windows for the **Toolchain: Verify** task.
- **Docs:** Rokit trust troubleshooting in `07-step-by-step-install-windows.md`; handoff note updated.

## Verified (cloud agent / Linux)

- `rokit install --no-trust-check` + `verify.sh` → all required tools OK
- `rojo serve` → listens on `localhost:34872`

## Windows next steps (user machine)

1. Step 0: open folder / checkout `cursor/karlux-foundation-292d`
2. Rokit install + PATH
3. `rokit install` (approve trust prompts)
4. `powershell -ExecutionPolicy Bypass -File staging\scripts\krlx-workspace-bootstrap.ps1`
5. **Tasks: Rojo: Serve** → Studio Connect → `/coins 5000` `/status`

**10-80-10:** merge to Karlux foundation branch after Karl/Eddie review; do not bulk-promote `staging/` → `src/` without approval.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21d158f8-029a-4f55-8319-ba853f2e0002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21d158f8-029a-4f55-8319-ba853f2e0002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

